### PR TITLE
Add `CVE-2021-45046` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # log4j-finder
 
-A Python3 script to scan the filesystem to find Log4j2 that is vulnerable to `Log4Shell (CVE-2021-44228)`
+A Python3 script to scan the filesystem to find Log4j2 that is vulnerable to _Log4Shell_ (`CVE-2021-44228` & `CVE-2021-45046`). 
 It scans recursively both on disk and inside Java Archive files (JARs).
 
 ![log4j-finder results](screenshot.png?raw=true "Output of log4j-finder")


### PR DESCRIPTION
`log4j-finder` already checks for `CVE-2021-45046` as part of commit bbfdb8bb54c54d3dd3f5e6440449ff39c394210d however there is no record of this on the README.

I nearly skipped over the project thinking it didn't check both vulnerabilities but thankfully read through the source and commit history first. So probably worth being explicit in the README in case anyone else dismisses this prematurely.