### PR TITLE
Fixing scanning issue of jars inside war files

### DIFF
--- a/log4j-finder.py
+++ b/log4j-finder.py
@@ -147,7 +147,7 @@ def iter_jarfile(fobj, parents=None, stats=None):
                     yield (zinfo, zfile, zpath, parents)
                 elif zpath.name.lower().endswith(JAR_EXTENSIONS):
                     yield from iter_jarfile(
-                        zfile.open(zinfo.filename), parents=parents + [zpath]
+                        io.BytesIO(zfile.open(zinfo.filename).read()), parents=parents + [zpath]
                     )
     except IOError as e:
         log.debug(f"{fobj}: {e}")


### PR DESCRIPTION
Current version would not scan zip files inside zip files properly (i.e., log4j jars inside *.war files)