### PR TITLE
Remove incorrect has_lookup=False for JndiLookup.class

### DIFF
--- a/log4j-finder.py
+++ b/log4j-finder.py
@@ -331,7 +331,7 @@ def main():
                                 try:
                                     has_lookup = zfile.open(lookup_path)
                                 except KeyError:
-                                    has_lookup = False
+                                    pass
                             check_vulnerable(zf, parents + [zpath], stats, has_lookup)
                 except IOError as e:
                     log.debug(f"{p}: {e}")


### PR DESCRIPTION
The exception handler set has_lookup=False, while it should remain True