### PR TITLE
Revert "Remove incorrect has_lookup=False for JndiLookup.class"

### DIFF
--- a/log4j-finder.py
+++ b/log4j-finder.py
@@ -343,7 +343,7 @@ def main():
                                 try:
                                     has_lookup = zfile.open(lookup_path.as_posix())
                                 except KeyError:
-                                    pass
+                                    has_lookup = False
                             check_vulnerable(zf, parents + [zpath], stats, has_lookup)
                 except IOError as e:
                     log.debug(f"{p}: {e}")


### PR DESCRIPTION
Reverts fox-it/log4j-finder#36

The old behaviour was actually correct, when there is a KeyError, it means no JndiLookup.class file is found. However the KeyError was also triggered due to non posix paths on Windows, that is now fixed in #37.